### PR TITLE
added setuptools flag to virtualenv else pip install fails :(

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Installation
 
     $ git clone https://github.com/jone/unison-tray.git
     $ cd unison-tray
-    $ virtualenv .
+    $ virtualenv . --setuptools
     $ source bin/activate
     $ pip install -r requirements.txt
 


### PR DESCRIPTION
Upgrading Distribute before installing PyObjC causes PyObjC compilation to fail with "can't find setuptools". Sigh. The fix is either "virtualenv . --setuptools" or rearranging the package order in requirements.txt -- this does the former to keep things as explicit as possible.
